### PR TITLE
fix typos

### DIFF
--- a/_docs/01-quick-start-guide.md
+++ b/_docs/01-quick-start-guide.md
@@ -35,7 +35,7 @@ redirect_from:
 将配置文件etc/conf/app.conf移到文件夹conf/下并修改相应的参数
 
 ```
-manager_cluster = "127.0.0.1:2379" #manager_cluster为ETCT地址
+manager_cluster = "127.0.0.1:2379" #manager_cluster为 ETCD 地址
 httpport = 9980 #httpport为Service Center绑定的端口
 ```
 

--- a/_docs/14-load-balance.md
+++ b/_docs/14-load-balance.md
@@ -119,6 +119,7 @@ cse:
 
 - 自定义分流策略
   业务可根据自己的需求实现自定义的分流策略，代码如下:
+
 ```java
 import io.servicecomb.loadbalance.filter.TransactionControlFilter;
 import com.netflix.loadbalancer.Server;

--- a/_docs/18-start-sc.md
+++ b/_docs/18-start-sc.md
@@ -29,7 +29,7 @@ redirect_from:
 将配置文件etc/conf/app.conf移到文件夹conf下并修改相应的参数
 
 ```
-manager_cluster = "127.0.0.1:2379" #manager_cluster为ETCT地址
+manager_cluster = "127.0.0.1:2379" #manager_cluster为 ETCD 地址
 httpport = 9980 #httpport为Service Center绑定的端口
 ```
 


### PR DESCRIPTION
- Two `ETCT` -> `ETCD`
- One place of source code is not rendered with syntax highlight due to the markdown error.