### PR TITLE
fixed url display in figure caption

### DIFF
--- a/_posts/2017-06-15-linuxcon-workshop-demo.md
+++ b/_posts/2017-06-15-linuxcon-workshop-demo.md
@@ -177,7 +177,7 @@ public class WorkerApplication {
 
 <figure class="align-center">
   <img src="{{ site.url }}{{ site.baseurl }}/assets/images/fibonaccitree.gif" alt="bee ancestors">
-  <figcaption>Credit: [Dave Cushman's website](http://www.dave-cushman.net)</figcaption>
+  <figcaption>Credit: <a href="http://www.dave-cushman.net">Dave Cushman's website</a></figcaption>
 </figure>
 
 参考上图，蜜蜂的某一代祖先数量符合黄金分割数列的模型，由此我们可以很快实现服务功能。

--- a/_posts/cn/2017-06-15-linuxcon-workshop-demo.md
+++ b/_posts/cn/2017-06-15-linuxcon-workshop-demo.md
@@ -177,7 +177,7 @@ public class WorkerApplication {
 
 <figure class="align-center">
   <img src="{{ site.url }}{{ site.baseurl }}/assets/images/fibonaccitree.gif" alt="bee ancestors">
-  <figcaption>Credit: [Dave Cushman's website](http://www.dave-cushman.net)</figcaption>
+  <figcaption>Credit: <a href="http://www.dave-cushman.net">Dave Cushman's website</a></figcaption>
 </figure>
 
 参考上图，蜜蜂的某一代祖先数量符合黄金分割数列的模型，由此我们可以很快实现服务功能。


### PR DESCRIPTION
Content in figure capture will be ignored in the markdown compile stage, we need to declare it explicitly in the html anchor syntax.