### PR TITLE
JAV-339 displayed posts' titles wider

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -185,6 +185,7 @@ defaults:
       comments: true
       share: true
       related: true
+      is_post: true
   # _pages
   - scope:
       path: "_pages"

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -43,17 +43,19 @@ layout: default
           <h4 class="page__meta-title">{{ site.data.ui-text[page.lang].meta_label }}</h4>
         {% endif %}
         {% include page__taxonomy.html %}
-        {% if page.lang == "cn" %}
-          {% if page.last_modified_at %}
-            <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> {{ site.data.ui-text[page.lang].date_label | default: "Updated:" }}</strong> <time datetime="{{ page.last_modified_at | date: "%Y-%m-%d" }}">{{ page.last_modified_at | date: "%Y年%-m月%-d日" }}</time></p>
-          {% elsif page.date %}
-            <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> {{ site.data.ui-text[page.lang].date_label | default: "Updated:" }}</strong> <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%Y年%-m月%-d日" }}</time></p>
-          {% endif %}
-        {% else %}
-          {% if page.last_modified_at %}
-            <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> {{ site.data.ui-text[page.lang].date_label | default: "Updated:" }}</strong> <time datetime="{{ page.last_modified_at | date: "%Y-%m-%d" }}">{{ page.last_modified_at | date: "%B %d, %Y" }}</time></p>
-          {% elsif page.date %}
-            <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> {{ site.data.ui-text[page.lang].date_label | default: "Updated:" }}</strong> <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %d, %Y" }}</time></p>
+        {% if page.is_post %}
+          {% if page.lang == "cn" %}
+            {% if page.last_modified_at %}
+              <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> {{ site.data.ui-text[page.lang].date_label | default: "Updated:" }}</strong> <time datetime="{{ page.last_modified_at | date: "%Y-%m-%d" }}">{{ page.last_modified_at | date: "%Y年%-m月%-d日" }}</time></p>
+            {% elsif page.date %}
+              <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> {{ site.data.ui-text[page.lang].date_label | default: "Updated:" }}</strong> <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%Y年%-m月%-d日" }}</time></p>
+            {% endif %}
+          {% else %}
+            {% if page.last_modified_at %}
+              <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> {{ site.data.ui-text[page.lang].date_label | default: "Updated:" }}</strong> <time datetime="{{ page.last_modified_at | date: "%Y-%m-%d" }}">{{ page.last_modified_at | date: "%B %d, %Y" }}</time></p>
+            {% elsif page.date %}
+              <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> {{ site.data.ui-text[page.lang].date_label | default: "Updated:" }}</strong> <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %d, %Y" }}</time></p>
+            {% endif %}
           {% endif %}
         {% endif %}
       </footer>

--- a/_sass/minimal-mistakes/_archive.scss
+++ b/_sass/minimal-mistakes/_archive.scss
@@ -83,7 +83,7 @@
    ========================================================================== */
 
 .list__item {
-  @include breakpoint($medium) {
+/*  @include breakpoint($medium) {
     padding-right: $right-sidebar-width-narrow;
   }
 
@@ -93,7 +93,7 @@
 
   @include breakpoint($x-large) {
     padding-right: $right-sidebar-width-wide;
-  }
+  } */
 
   .page__meta {
     margin: 0 0 4px;

--- a/_sass/minimal-mistakes/_archive.scss
+++ b/_sass/minimal-mistakes/_archive.scss
@@ -72,9 +72,9 @@
     box-shadow: 0 0 10px rgba(#000, 0.25);
   }
 
-  .archive__item-title {
+/*  .archive__item-title {
     text-decoration: underline;
-  }
+  } */
 }
 
 


### PR DESCRIPTION
The original *list__item* class pads right too much(200, 300, 400 pixels) so only a few words can be displayed in a single line. Now we remove this restriction and the titles can be displayed in one line.